### PR TITLE
Avoid manual asset handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,18 @@
 			"name": "static-frontend-container-backend-template",
 			"version": "0.0.3",
 			"dependencies": {
-				"@cloudflare/containers": "^0.0.10"
+				"@cloudflare/containers": "^0.0.12"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20250506.0",
 				"typescript": "^5.5.2",
-				"wrangler": "^4.18.0"
+				"wrangler": "^4.21.0"
 			}
 		},
 		"node_modules/@cloudflare/containers": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.0.10.tgz",
-			"integrity": "sha512-0C4YZEBhqBvOLGCRB2jv7MDvX4KGdiDqy6XfefBp/lP0cLGkXb1+yrDvPv5wxnjBwzEpNZ5qAoFTqN6WH6gF8A==",
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.0.12.tgz",
+			"integrity": "sha512-LKx76VpMmJDeagOrDCZWnOnt7psfe8T7FI6HfeVjJlWJCd7xLiMYi9aR9d+noYIuvO5SdPLTalFI9q9acFR98g==",
 			"license": "ISC"
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -1056,9 +1056,9 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.20.5",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.20.5.tgz",
-			"integrity": "sha512-tmiyt2vBHszhdzJEDbCpFLU2RiV7/QzvGMV07Zaz4ptqiU2h/lTojyNJAugPpSFNiOuY+k0g3ENNTDQqoUkMFA==",
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.21.0.tgz",
+			"integrity": "sha512-37xm0CG2qMvsJUNZYQKje6HbCsJFYuE8dQSnu7981iDRT4DLrEIL1DAUnZJG9HiXteKPvrSj96AkZyomi5sYHw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250506.0",
 		"typescript": "^5.5.2",
-		"wrangler": "^4.18.0"
+		"wrangler": "^4.21.0"
 	},
 	"dependencies": {
-		"@cloudflare/containers": "^0.0.10"
+		"@cloudflare/containers": "^0.0.12"
 	},
 	"cloudflare": {
 		"label": "Containers Starter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export class Backend extends Container {
 
 export interface Env {
   BACKEND: DurableObjectNamespace<Backend>;
-  ASSETS: Fetcher;
 }
 
 const INSTANCE_COUNT = 3;
@@ -18,10 +17,9 @@ export default {
     if (url.pathname.startsWith("/api")) {
       // note: "getRandom" to be replaced with latency-aware routing in the near future
       // this is a temporary helper
-      const containerInstance = await getRandom(env.BACKEND, INSTANCE_COUNT)
+      const containerInstance = await getRandom(env.BACKEND, INSTANCE_COUNT);
       return containerInstance.fetch(request);
     }
-
-    return env.ASSETS.fetch(request);
+    return new Response("Not Found", { status: 404 });
   },
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,8 +18,7 @@
 	"containers": [
 		{
 			"class_name": "Backend",
-			"name": "backend",
-			"configuration": { "image": "./Dockerfile" },
+			"image": "./Dockerfile",
 			"max_instances": 3
 		}
 	],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,14 +10,17 @@
 		"enabled": true
 	},
 	"assets": {
-    "directory": "./dist",
-    "binding": "ASSETS"
-  },
+		"directory": "./dist",
+		"run_worker_first": [
+			"/api/*" // API routes skip static asset handling
+		]
+	},
 	"containers": [
 		{
 			"class_name": "Backend",
-			"image": "./Dockerfile",
-			"max_instances": 3,
+			"name": "backend",
+			"configuration": { "image": "./Dockerfile" },
+			"max_instances": 3
 		}
 	],
 	"durable_objects": {


### PR DESCRIPTION
There's no need for `env.ASSETS.fetch(request)` (indeed it does nothing – it will only ever serve up a 404 because all valid asset paths have already been checked before the Worker is invoked)